### PR TITLE
Update Socket.cpp

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -33,6 +33,10 @@
  */
 
 #include "Socket.h"
+
+#ifdef __MINGW32__
+#undef ERROR
+#endif
 #include "../log/log.h"
 #include <memory.h>
 


### PR DESCRIPTION
`ERROR` is defined somewhere as an identifier within the MinGW distribution; undefine their version since we are using our own.