### PR TITLE
Various small Win32 fixes

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -35,6 +35,7 @@
 #include "Socket.h"
 #include "../log/log.h"
 #include <ctime>
+#include <cmath>
 #include <memory.h>
 
 #ifndef _WIN32
@@ -560,12 +561,20 @@ bool Socket::DisableNagle()
 
 bool Socket::SetRxTimeout(unsigned int microSeconds)
 {
+#ifdef _WIN32
+	// WinSock2 expects a DWORD here, that contains the timeout in milliseconds.
+	DWORD timeout = (DWORD)(ceil((float)microSeconds / 1000.0f));
+
+	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_RCVTIMEO, (const char*)timeout, sizeof(DWORD)))
+		return false;
+#else
 	struct timeval tv;
 	tv.tv_sec = 0;
 	tv.tv_usec = (suseconds_t)microSeconds;
 
 	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_RCVTIMEO, &tv, sizeof(tv)))
 		return false;
+#endif
 
 	m_rxtimeout = microSeconds;
 	return true;
@@ -573,11 +582,19 @@ bool Socket::SetRxTimeout(unsigned int microSeconds)
 
 bool Socket::SetTxTimeout(unsigned int microSeconds)
 {
+#ifdef _WIN32
+	// WinSock2 expects a DWORD here, that contains the timeout in milliseconds.
+	DWORD timeout = (DWORD)(ceil((float)microSeconds / 1000.0f));
+
+	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_RCVTIMEO, (const char*)timeout, sizeof(DWORD)))
+		return false;
+#else
 	struct timeval tv;
 	tv.tv_sec = 0;
 	tv.tv_usec = (suseconds_t)microSeconds;
 	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_SNDTIMEO, &tv, sizeof(tv)))
 		return false;
+#endif
 
 	m_txtimeout = microSeconds;
 	return true;

--- a/UART.cpp
+++ b/UART.cpp
@@ -82,7 +82,7 @@ UART::UART(const std::string& devfile, int baud)
 		(const void)devfile;
 		(const void)baud;
 		m_fd = INVALID_HANDLE_VALUE;
-		LogError("Windows UART stuff not implemented",);
+		LogError("Windows UART stuff not implemented");
 		return;
 	#else
 		//Open the UART


### PR DESCRIPTION
This PR contains some smaller fixes that allows xptools to be compiled on Windows using MSYS2/Mingw64.

- WinSock2s does not support the passing of a time struct as socket timeout value. A DWORD is expected instead. Since WinSock2 only has a precision of 1 ms, the timeout value is rounded up to the next millisecond
- A stray comma in the UART code