### PR TITLE
Fix Socket::SetRxTimeout & Socket::SetTxTimeout setsockopt() level parameter

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -582,15 +582,14 @@ bool Socket::SetRxTimeout(unsigned int microSeconds)
 #ifdef _WIN32
 	// WinSock2 expects a DWORD here, that contains the timeout in milliseconds.
 	DWORD timeout = (DWORD)(ceil((float)microSeconds / 1000.0f));
-
-	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_RCVTIMEO, (const char*)&timeout, sizeof(DWORD)))
+	if(0 != setsockopt((ZSOCKET)m_socket, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(DWORD)))
 		return false;
 #else
 	struct timeval tv;
 	tv.tv_sec = microSeconds/1000000;
 	tv.tv_usec = (suseconds_t)(microSeconds%1000000);
 
-	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_RCVTIMEO, &tv, sizeof(tv)))
+	if(0 != setsockopt((ZSOCKET)m_socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)))
 		return false;
 #endif
 
@@ -603,14 +602,13 @@ bool Socket::SetTxTimeout(unsigned int microSeconds)
 #ifdef _WIN32
 	// WinSock2 expects a DWORD here, that contains the timeout in milliseconds.
 	DWORD timeout = (DWORD)(ceil((float)microSeconds / 1000.0f));
-
-	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_SNDTIMEO, (const char*)&timeout, sizeof(DWORD)))
+	if(0 != setsockopt((ZSOCKET)m_socket, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(DWORD)))
 		return false;
 #else
 	struct timeval tv;
 	tv.tv_sec = microSeconds/1000000;
 	tv.tv_usec = (suseconds_t)(microSeconds%1000000);
-	if(0 != setsockopt((ZSOCKET)m_socket, m_type, SO_SNDTIMEO, &tv, sizeof(tv)))
+	if(0 != setsockopt((ZSOCKET)m_socket, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)))
 		return false;
 #endif
 


### PR DESCRIPTION
Fix Socket::SetRxTimeout & Socket::SetTxTimeout setsockopt() level parameter shall be set to SOL_SOCKET for WIN32 & Linux instead of m_type which is set to SOCK_STREAM