### PR TITLE
fixes for BSD

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -601,7 +601,7 @@ bool Socket::DisableNagle()
  */
 bool Socket::DisableDelayedACK()
 {
-#ifndef _WIN32
+#ifdef TCP_QUICKACK
 	int flag = 1;
 	if(0 != setsockopt((int)m_socket, IPPROTO_TCP, TCP_QUICKACK, (char*)&flag, sizeof(flag)))
 		return false;


### PR DESCRIPTION
as TCP_QUICKACK is just a linux feature test for it
BSD's termios supports custom baud rates, therefore it can be used, keep termios2 for linux