### PR TITLE
Adds Windows UART read timeout to prevent blocking read thread in case of non responding device.

### DIFF
--- a/UART.cpp
+++ b/UART.cpp
@@ -160,9 +160,9 @@ bool UART::Connect(const std::string& devfile, int baud)
 		// Set timeouts
 		COMMTIMEOUTS timeouts;
 		SecureZeroMemory(&timeouts, sizeof(COMMTIMEOUTS));
-		timeouts.ReadIntervalTimeout        = 50; // in milliseconds
-		timeouts.ReadTotalTimeoutConstant   = 50; // in milliseconds
-		timeouts.ReadTotalTimeoutMultiplier = 10; // in milliseconds
+		timeouts.ReadIntervalTimeout        = 50; // Timeout between each byte (in milliseconds)
+		timeouts.ReadTotalTimeoutConstant   = 500;// Total timeout for a read operation (in milliseconds)
+		timeouts.ReadTotalTimeoutMultiplier = 1;  // Multiplier for each byte
 		timeouts.WriteTotalTimeoutConstant  = 50; // in milliseconds
 		timeouts.WriteTotalTimeoutMultiplier = 10;// in milliseconds
 		result = SetCommTimeouts(m_fd, &timeouts);
@@ -278,7 +278,8 @@ bool UART::Read(unsigned char* data, int len)
              					(char*)data,    //Temporary character
              					len,			//Size of TempChar
              					&x,   			//Number of bytes read
-             					NULL))
+             					NULL) 
+								&& (x != 0))	// Stop when stream is empty
 			{
 				len -= x;
 				data += x;


### PR DESCRIPTION
This PR adds a timeout to UART read operations on Windows.
Timeout has been configured to 500ms for a global read operation and 50ms per byte which should be more than enough event for slow devices.