### PR TITLE
Fix socket error for slow devices

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -304,9 +304,9 @@ bool Socket::RecvLooped(unsigned char* buf, int len)
 	{
 		x = recv(m_socket, (char*)p, bytes_left, MSG_WAITALL);
 
-		//Handle EINTR
+		//Handle EINTR and EAGAIN
 		#ifndef _WIN32
-		if( (x < 0) && (errno == EINTR))
+		if((x < 0) && (errno == EINTR) && (errno == EAGAIN))
 			continue;
 		#endif
 


### PR DESCRIPTION
recv() will return EAGAIN if **no** data is available. 

This fixes a case where the device is to slow to send data in time and helps to drain the output buffer on the device to keep the connection in sync.

The risk for misbehavior is low as there is a timeout in place.