### PR TITLE
Fix for finding hidapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,15 @@ add_library(xptools STATIC
 	HID.cpp
 	TimeUtil.cpp)
 
-if(UNIX AND NOT APPLE)
-	# hidapi-config.cmake not provided by ubuntu usbapi package
-	target_link_libraries(xptools hidapi-hidraw)
-else()
-	find_package(hidapi REQUIRED)
-	target_link_libraries(xptools hidapi::hidapi)
+find_package(PkgConfig MODULE REQUIRED)
+
+pkg_check_modules(HIDAPI QUIET IMPORTED_TARGET hidapi-hidraw) # look for older version too
+if(NOT HIDAPI_FOUND)
+	message(FATAL_ERROR "Unable to find any version of hidapi-hidraw; this is required to build xptools (part of ngscopeclient).")
 endif()
+
+target_include_directories(xptools SYSTEM PRIVATE ${HIDAPI_INCLUDE_DIRS})
+target_link_libraries(xptools PRIVATE ${HIDAPI_LIBRARIES})
 
 if(WIN32)
 target_link_libraries(xptools ws2_32)


### PR DESCRIPTION
Finding hidapi requires pkgconfig as it doesn't ship CMake files. This tries to correctly look for it.