### PR TITLE
Check if using termios2 is necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,19 @@ add_library(xptools STATIC
 	HID.cpp
 	TimeUtil.cpp)
 
+if(UNIX)
+	include(CheckStructHasMember)
+	check_struct_has_member(
+		termios
+		c_ispeed
+		termios.h
+		TERMIOS_HAS_ISPEED
+		LANGUAGE CXX)
+	if(NOT TERMIOS_HAS_ISPEED)
+		target_compile_definitions(xptools PRIVATE "USE_TERMIOS2")
+	endif()
+endif()
+
 find_package(PkgConfig MODULE REQUIRED)
 
 pkg_check_modules(HIDAPI IMPORTED_TARGET hidapi)

--- a/UART.cpp
+++ b/UART.cpp
@@ -41,7 +41,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#ifdef __linux__
+#ifdef USE_TERMIOS2
 #include <asm/termios.h>
 
 //asm/termios.h seems to conflict with sys/ioctl.h and termios.h
@@ -186,7 +186,7 @@ bool UART::Connect(const std::string& devfile, int baud, [[maybe_unused]] bool d
 		}
 
 		//Set flags - linux doesn't support custom bauds in termios
-#ifdef __linux__
+#ifdef USE_TERMIOS2
 		termios2 flags;
 		memset(&flags, 0, sizeof(flags));
 		ioctl(m_fd, TCGETS2, &flags);


### PR DESCRIPTION
This is only on some Linux architectures.